### PR TITLE
Drop non-unique `-n` option for archive import

### DIFF
--- a/src/aiida/cmdline/commands/cmd_archive.py
+++ b/src/aiida/cmdline/commands/cmd_archive.py
@@ -323,7 +323,6 @@ class ExtrasImportCode(Enum):
     'mirror: import all extras and remove any existing extras that are not present in the archive. ',
 )
 @click.option(
-    '-n',
     '--extras-mode-new',
     type=click.Choice(EXTRAS_MODE_NEW),
     default='import',


### PR DESCRIPTION
Short option for `--extras-mode-new`

## Summary by Sourcery

Enhancements:
- Drop the `-n` alias from the `--extras-mode-new` click option in cmd_archive.py.