### PR TITLE
Apply `filter_size` to all archive import functions

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -127,6 +127,8 @@ py:class aiida.cmdline.params.types.choice.T
 py:class aiida.common.lang.T
 py:class aiida.engine.processes.functions.N
 py:class aiida.engine.processes.functions.R_co
+py:class aiida.common.utils.T
+py:class aiida.common.utils.R
 
 ### third-party packages
 # Note: These exceptions are needed if

--- a/src/aiida/cmdline/commands/cmd_archive.py
+++ b/src/aiida/cmdline/commands/cmd_archive.py
@@ -26,6 +26,7 @@ from aiida.cmdline.utils import decorators, echo
 from aiida.common.exceptions import CorruptStorage, IncompatibleStorageSchema, UnreachableStorage
 from aiida.common.links import GraphTraversalRules
 from aiida.common.log import AIIDA_LOGGER
+from aiida.common.utils import DEFAULT_BATCH_SIZE, DEFAULT_FILTER_SIZE
 
 EXTRAS_MODE_EXISTING = ['keep_existing', 'update_existing', 'mirror', 'none']
 EXTRAS_MODE_NEW = ['import', 'none']
@@ -130,7 +131,11 @@ def inspect(ctx, archive, version, meta_data, database):
 )
 @click.option('--compress', default=6, show_default=True, type=int, help='Level of compression to use (0-9).')
 @click.option(
-    '-b', '--batch-size', default=1000, type=int, help='Stream database rows in batches, to reduce memory usage.'
+    '-b',
+    '--batch-size',
+    default=DEFAULT_BATCH_SIZE,
+    type=int,
+    help='Stream database rows in batches, to reduce memory usage.',
 )
 @click.option(
     '--test-run',
@@ -210,6 +215,7 @@ def create(
         'overwrite': force,
         'compression': compress,
         'batch_size': batch_size,
+        'filter_size': DEFAULT_FILTER_SIZE,  # Implementation detail, not exposed to user via CLI
         'test_run': dry_run,
     }
 

--- a/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
+++ b/src/aiida/storage/sqlite_zip/migrations/legacy_to_main.py
@@ -131,7 +131,7 @@ def _json_to_sqlite(
     outpath: Path, data: dict, node_repos: Dict[str, List[Tuple[str, Optional[str]]]], batch_size: int = 100
 ) -> None:
     """Convert a JSON archive format to SQLite."""
-    from aiida.tools.archive.common import batch_iter
+    from aiida.common.utils import batch_iter
 
     from . import v1_db_schema as v1_schema
 

--- a/src/aiida/tools/archive/common.py
+++ b/src/aiida/tools/archive/common.py
@@ -11,7 +11,7 @@
 import urllib.parse
 import urllib.request
 from html.parser import HTMLParser
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+from typing import Dict, Type
 
 from aiida.orm import AuthInfo, Comment, Computer, Entity, Group, Log, Node, User
 from aiida.orm.entities import EntityTypes
@@ -26,30 +26,6 @@ entity_type_to_orm: Dict[EntityTypes, Type[Entity]] = {
     EntityTypes.NODE: Node,
     EntityTypes.COMMENT: Comment,
 }
-
-
-def batch_iter(
-    iterable: Iterable[Any], size: int, transform: Optional[Callable[[Any], Any]] = None
-) -> Iterable[Tuple[int, List[Any]]]:
-    """Yield an iterable in batches of a set number of items.
-
-    Note, the final yield may be less than this size.
-
-    :param transform: a transform to apply to each item
-    :returns: (number of items, list of items)
-    """
-    transform = transform or (lambda x: x)
-    current = []
-    length = 0
-    for item in iterable:
-        current.append(transform(item))
-        length += 1
-        if length >= size:
-            yield length, current
-            current = []
-            length = 0
-    if current:
-        yield length, current
 
 
 class HTMLGetLinksParser(HTMLParser):

--- a/src/aiida/tools/archive/create.py
+++ b/src/aiida/tools/archive/create.py
@@ -14,18 +14,19 @@ stored in a single file.
 
 import shutil
 import tempfile
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Iterable, Optional, Sequence, Union
+from typing import Any, Callable, Iterable, Optional, Union
 
 from tabulate import tabulate
 
 from aiida import orm
-from aiida.common.exceptions import LicensingException
 from aiida.common.lang import type_check
 from aiida.common.links import GraphTraversalRules
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.progress_reporter import get_progress_reporter
+from aiida.common.utils import DEFAULT_BATCH_SIZE, DEFAULT_FILTER_SIZE, batch_iter
 from aiida.manage import get_manager
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import StorageBackend
@@ -33,7 +34,7 @@ from aiida.orm.utils.links import LinkQuadruple
 from aiida.tools.graph.graph_traversers import get_nodes_export, validate_traversal_rules
 
 from .abstract import ArchiveFormatAbstract, ArchiveWriterAbstract
-from .common import batch_iter, entity_type_to_orm
+from .common import entity_type_to_orm
 from .exceptions import ArchiveExportError, ExportValidationError
 from .implementations.sqlite_zip import ArchiveFormatSqlZip
 
@@ -55,7 +56,8 @@ def create_archive(
     allowed_licenses: Optional[Union[list, Callable]] = None,
     forbidden_licenses: Optional[Union[list, Callable]] = None,
     strip_checkpoints: bool = True,
-    batch_size: int = 1000,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    filter_size: int = DEFAULT_FILTER_SIZE,
     compression: int = 6,
     test_run: bool = False,
     backend: Optional[StorageBackend] = None,
@@ -134,6 +136,9 @@ def create_archive(
     :param compression: level of compression to use (integer from 0 to 9)
 
     :param batch_size: batch database query results in sub-collections to reduce memory usage
+
+    :param filter_size: query filters are batched by this number to avoid database parameter limits. Try reducing
+        this value in case you run into related errors.
 
     :param test_run: if True, do not write to file
 
@@ -250,14 +255,15 @@ def create_archive(
             include_logs,
             backend,
             batch_size,
+            filter_size,
         )
 
     # now all the nodes have been retrieved, perform some checks
     if entity_ids[EntityTypes.NODE]:
         EXPORT_LOGGER.report('Validating Nodes')
-        _check_unsealed_nodes(querybuilder, entity_ids[EntityTypes.NODE], batch_size)
+        _check_unsealed_nodes(querybuilder, entity_ids[EntityTypes.NODE], batch_size, filter_size)
         _check_node_licenses(
-            querybuilder, entity_ids[EntityTypes.NODE], allowed_licenses, forbidden_licenses, batch_size
+            querybuilder, entity_ids[EntityTypes.NODE], allowed_licenses, forbidden_licenses, batch_size, filter_size
         )
 
     # get a count of entities, to report
@@ -268,11 +274,17 @@ def create_archive(
 
     if test_run:
         EXPORT_LOGGER.report('Test Run: Stopping before archive creation')
-        if node_ids := list(entity_ids[EntityTypes.NODE]):
-            keys = set(
-                orm.Node.get_collection(backend).iter_repo_keys(filters={'id': {'in': node_ids}}, batch_size=batch_size)
-            )
-            count_summary.append(['Repository Files', len(keys)])
+        if node_ids := entity_ids[EntityTypes.NODE]:
+            # Batch the node IDs to avoid parameter limits in dry run as well
+            all_keys = set()
+            for _, node_batch_ids in batch_iter(node_ids, filter_size):
+                batch_keys = set(
+                    orm.Node.get_collection(backend).iter_repo_keys(
+                        filters={'id': {'in': node_batch_ids}}, batch_size=batch_size
+                    )
+                )
+                all_keys.update(batch_keys)
+            count_summary.append(['Repository Files', len(all_keys)])
         else:
             count_summary.append(['Repository Files', 0])
         EXPORT_LOGGER.report(f'Archive would be created with:\n{tabulate(count_summary)}')
@@ -318,17 +330,22 @@ def create_archive(
 
                     progress.set_description_str(f'Archiving database: {etype.value}s')
                     if ids:
-                        for nrows, rows in batch_iter(
-                            querybuilder()
-                            .append(
-                                entity_type_to_orm[etype], filters={'id': {'in': ids}}, tag='entity', project=['**']
+                        # Batch also the IDs to avoid query filter parameter limits
+                        for _, batch_ids in batch_iter(ids, filter_size):
+                            # Build the query for this batch of IDs
+                            query = querybuilder().append(
+                                entity_type_to_orm[etype],
+                                filters={'id': {'in': batch_ids}},
+                                tag='entity',
+                                project=['**'],
                             )
-                            .iterdict(batch_size=batch_size),
-                            batch_size,
-                            transform,
-                        ):
-                            writer.bulk_insert(etype, rows)
-                            progress.update(nrows)
+
+                            # Process the query results in batches
+                            query_results = query.iterdict(batch_size=batch_size)
+
+                            for nrows, rows in batch_iter(query_results, batch_size, transform):
+                                writer.bulk_insert(etype, rows)
+                                progress.update(nrows)
 
                 # stream links
                 progress.set_description_str(f'Archiving database: {EntityTypes.LINK.value}s')
@@ -359,7 +376,9 @@ def create_archive(
 
             # stream node repository files to the archive
             if entity_ids[EntityTypes.NODE]:
-                _stream_repo_files(archive_format.key_format, writer, entity_ids[EntityTypes.NODE], backend, batch_size)
+                _stream_repo_files(
+                    archive_format.key_format, writer, entity_ids[EntityTypes.NODE], backend, batch_size, filter_size
+                )
 
             EXPORT_LOGGER.report('Finalizing archive creation...')
 
@@ -381,7 +400,7 @@ def _collect_all_entities(
     include_comments: bool,
     include_logs: bool,
     batch_size: int,
-) -> tuple[list[tuple[int, int]], set[LinkQuadruple]]:
+) -> tuple[list[list[int]], set[LinkQuadruple]]:
     """Collect all entities.
 
     :returns: (group_id_to_node_id, link_data) and updates entity_ids
@@ -425,7 +444,7 @@ def _collect_all_entities(
             .append(orm.Node, with_group='group', project='id')
             .distinct()
         )
-        group_nodes: list[tuple[int, int]] = qbuilder.all(batch_size=batch_size)  # type: ignore[assignment]
+        group_nodes: list[list[int]] = qbuilder.all(batch_size=batch_size)
 
         progress.set_description_str(progress_str('Computers'))
         progress.update()
@@ -497,7 +516,8 @@ def _collect_required_entities(
     include_logs: bool,
     backend: StorageBackend,
     batch_size: int,
-) -> tuple[list[tuple[int, int]], set[LinkQuadruple]]:
+    filter_size: int,
+) -> tuple[list[list[int]], set[LinkQuadruple]]:
     """Collect required entities, given a set of starting entities and provenance graph traversal rules.
 
     :returns: (group_id_to_node_id, link_data) and updates entity_ids
@@ -509,16 +529,16 @@ def _collect_required_entities(
     with get_progress_reporter()(desc=progress_str(''), total=7) as progress:
         # get all nodes from groups
         progress.set_description_str(progress_str('Nodes (groups)'))
-        group_nodes: list[tuple[int, int]] = []
-        if entity_ids[EntityTypes.GROUP]:
-            qbuilder = querybuilder()
-            qbuilder.append(
-                orm.Group, filters={'id': {'in': list(entity_ids[EntityTypes.GROUP])}}, project='id', tag='group'
-            )
-            qbuilder.append(orm.Node, with_group='group', project='id')
-            qbuilder.distinct()
-            group_nodes = qbuilder.all(batch_size=batch_size)  # type: ignore[assignment]
-            entity_ids[EntityTypes.NODE].update(nid for _, nid in group_nodes)
+        group_nodes: list[list[int]] = []
+        if ids := entity_ids[EntityTypes.GROUP]:
+            for _, group_batch_ids in batch_iter(ids, filter_size):
+                qbuilder = querybuilder()
+                qbuilder.append(orm.Group, filters={'id': {'in': group_batch_ids}}, project='id', tag='group')
+                qbuilder.append(orm.Node, with_group='group', project='id')
+                qbuilder.distinct()
+                batch_group_nodes = qbuilder.all(batch_size=batch_size)
+                group_nodes.extend(batch_group_nodes)
+                entity_ids[EntityTypes.NODE].update(nid for _, nid in batch_group_nodes)
 
         # get full set of nodes & links, following traversal rules
         progress.set_description_str(progress_str('Nodes (traversal)'))
@@ -533,94 +553,102 @@ def _collect_required_entities(
         progress.update()
 
         # get full set of computers
-        if entity_ids[EntityTypes.NODE]:
-            entity_ids[EntityTypes.COMPUTER].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Node, filters={'id': {'in': list(entity_ids[EntityTypes.NODE])}}, tag='node')
-                .append(orm.Computer, with_node='node', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
+        if ids := entity_ids[EntityTypes.NODE]:
+            for _, node_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.COMPUTER].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Node, filters={'id': {'in': node_batch_ids}}, tag='node')
+                    .append(orm.Computer, with_node='node', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
 
         # get full set of authinfos
         progress.set_description_str(progress_str('AuthInfos'))
         progress.update()
-        if include_authinfos and entity_ids[EntityTypes.COMPUTER]:
-            entity_ids[EntityTypes.AUTHINFO].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Computer, filters={'id': {'in': list(entity_ids[EntityTypes.COMPUTER])}}, tag='comp')
-                .append(orm.AuthInfo, with_computer='comp', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
+        if include_authinfos and (ids := entity_ids[EntityTypes.COMPUTER]):
+            for _, computer_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.AUTHINFO].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Computer, filters={'id': {'in': computer_batch_ids}}, tag='comp')
+                    .append(orm.AuthInfo, with_computer='comp', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
 
         # get full set of logs
         progress.set_description_str(progress_str('Logs'))
         progress.update()
-        if include_logs and entity_ids[EntityTypes.NODE]:
-            entity_ids[EntityTypes.LOG].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Node, filters={'id': {'in': list(entity_ids[EntityTypes.NODE])}}, tag='node')
-                .append(orm.Log, with_node='node', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
+        if include_logs and (ids := entity_ids[EntityTypes.NODE]):
+            for _, node_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.LOG].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Node, filters={'id': {'in': node_batch_ids}}, tag='node')
+                    .append(orm.Log, with_node='node', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
 
         # get full set of comments
         progress.set_description_str(progress_str('Comments'))
         progress.update()
-        if include_comments and entity_ids[EntityTypes.NODE]:
-            entity_ids[EntityTypes.COMMENT].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Node, filters={'id': {'in': list(entity_ids[EntityTypes.NODE])}}, tag='node')
-                .append(orm.Comment, with_node='node', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
+        if include_comments and (ids := entity_ids[EntityTypes.NODE]):
+            for _, node_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.COMMENT].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Node, filters={'id': {'in': node_batch_ids}}, tag='node')
+                    .append(orm.Comment, with_node='node', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
 
         # get full set of users
         progress.set_description_str(progress_str('Users'))
         progress.update()
-        if entity_ids[EntityTypes.NODE]:
-            entity_ids[EntityTypes.USER].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Node, filters={'id': {'in': list(entity_ids[EntityTypes.NODE])}}, tag='node')
-                .append(orm.User, with_node='node', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
-        if entity_ids[EntityTypes.GROUP]:
-            entity_ids[EntityTypes.USER].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Group, filters={'id': {'in': list(entity_ids[EntityTypes.GROUP])}}, tag='group')
-                .append(orm.User, with_group='group', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
-        if entity_ids[EntityTypes.COMMENT]:
-            entity_ids[EntityTypes.USER].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.Comment, filters={'id': {'in': list(entity_ids[EntityTypes.COMMENT])}}, tag='comment')
-                .append(orm.User, with_comment='comment', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
-        if entity_ids[EntityTypes.AUTHINFO]:
-            entity_ids[EntityTypes.USER].update(
-                pk
-                for (pk,) in querybuilder()
-                .append(orm.AuthInfo, filters={'id': {'in': list(entity_ids[EntityTypes.AUTHINFO])}}, tag='auth')
-                .append(orm.User, with_authinfo='auth', project='id')
-                .distinct()
-                .iterall(batch_size=batch_size)
-            )
+        if ids := entity_ids[EntityTypes.NODE]:
+            for _, node_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.USER].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Node, filters={'id': {'in': node_batch_ids}}, tag='node')
+                    .append(orm.User, with_node='node', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
+        if ids := entity_ids[EntityTypes.GROUP]:
+            for _, group_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.USER].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Group, filters={'id': {'in': group_batch_ids}}, tag='group')
+                    .append(orm.User, with_group='group', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
+        if ids := entity_ids[EntityTypes.COMMENT]:
+            for _, comment_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.USER].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.Comment, filters={'id': {'in': comment_batch_ids}}, tag='comment')
+                    .append(orm.User, with_comment='comment', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
+        if ids := entity_ids[EntityTypes.AUTHINFO]:
+            for _, authinfo_batch_ids in batch_iter(ids, filter_size):
+                entity_ids[EntityTypes.USER].update(
+                    pk
+                    for (pk,) in querybuilder()
+                    .append(orm.AuthInfo, filters={'id': {'in': authinfo_batch_ids}}, tag='auth')
+                    .append(orm.User, with_authinfo='auth', project='id')
+                    .distinct()
+                    .iterall(batch_size=batch_size)
+                )
 
         progress.update()
 
@@ -628,12 +656,25 @@ def _collect_required_entities(
 
 
 def _stream_repo_files(
-    key_format: str, writer: ArchiveWriterAbstract, node_ids: set[int], backend: StorageBackend, batch_size: int
+    key_format: str,
+    writer: ArchiveWriterAbstract,
+    node_ids: set[int],
+    backend: StorageBackend,
+    batch_size: int,
+    filter_size: int,
 ) -> None:
     """Collect all repository object keys from the nodes, then stream the files to the archive."""
-    keys = set(
-        orm.Node.get_collection(backend).iter_repo_keys(filters={'id': {'in': list(node_ids)}}, batch_size=batch_size)
-    )
+
+    # Batch the node IDs to avoid parameter limits when getting repo keys
+    all_keys = set()
+
+    for _, node_batch_ids in batch_iter(node_ids, filter_size):
+        batch_keys = set(
+            orm.Node.get_collection(backend).iter_repo_keys(
+                filters={'id': {'in': node_batch_ids}}, batch_size=batch_size
+            )
+        )
+        all_keys.update(batch_keys)
 
     repository = backend.get_repository()
     if not repository.key_format == key_format:
@@ -641,34 +682,42 @@ def _stream_repo_files(
         raise NotImplementedError(
             f'Backend repository key format incompatible: {repository.key_format!r} != {key_format!r}'
         )
-    with get_progress_reporter()(desc='Archiving files: ', total=len(keys)) as progress:
-        for key, stream in repository.iter_object_streams(keys):  # type: ignore[arg-type]
+    with get_progress_reporter()(desc='Archiving files: ', total=len(all_keys)) as progress:
+        for key, stream in repository.iter_object_streams(all_keys):  # type: ignore[arg-type]
             # to-do should we use assume the key here is correct, or always re-compute and check?
             writer.put_object(stream, key=key)
             progress.update()
 
 
-def _check_unsealed_nodes(querybuilder: QbType, node_ids: set[int], batch_size: int) -> None:
+def _check_unsealed_nodes(querybuilder: QbType, node_ids: set[int], batch_size: int, filter_size: int) -> None:
     """Check no process nodes are unsealed, i.e. all processes have completed."""
-    qbuilder = (
-        querybuilder()
-        .append(
-            orm.ProcessNode,
-            filters={
-                'id': {'in': list(node_ids)},
-                'attributes.sealed': {
-                    '!in': [True]  # better operator?
+    if not node_ids:
+        return
+
+    all_unsealed_pks = []
+
+    for _, node_batch_ids in batch_iter(node_ids, filter_size):
+        qbuilder = (
+            querybuilder()
+            .append(
+                orm.ProcessNode,
+                filters={
+                    'id': {'in': node_batch_ids},
+                    'attributes.sealed': {
+                        '!in': [True]  # better operator?
+                    },
                 },
-            },
-            project='id',
+                project='id',
+            )
+            .distinct()
         )
-        .distinct()
-    )
-    unsealed_node_pks = qbuilder.all(batch_size=batch_size, flat=True)
-    if unsealed_node_pks:
+        batch_unsealed_pks = qbuilder.all(batch_size=batch_size, flat=True)
+        all_unsealed_pks.extend(batch_unsealed_pks)
+
+    if all_unsealed_pks:
         raise ExportValidationError(
             'All ProcessNodes must be sealed before they can be exported. '
-            f"Node(s) with PK(s): {', '.join(str(pk) for pk in unsealed_node_pks)} is/are not sealed."
+            f'Node(s) with PK(s): {", ".join(str(pk) for pk in all_unsealed_pks)} is/are not sealed.'
         )
 
 
@@ -678,8 +727,12 @@ def _check_node_licenses(
     allowed_licenses: Union[None, Sequence[str], Callable],
     forbidden_licenses: Union[None, Sequence[str], Callable],
     batch_size: int,
+    filter_size: int,
 ) -> None:
     """Check the nodes to be archived for disallowed licences."""
+
+    from aiida.common.exceptions import LicensingException
+
     if allowed_licenses is None and forbidden_licenses is None:
         return None
 
@@ -725,24 +778,25 @@ def _check_node_licenses(
     else:
         raise TypeError('forbidden_licenses not a list or function')
 
-    # create query
-    qbuilder = querybuilder().append(
-        orm.Node,
-        project=['id', 'attributes.source.license'],
-        filters={'id': {'in': list(node_ids)}},
-    )
+    for _, node_batch_ids in batch_iter(node_ids, filter_size):
+        # create query for this batch
+        qbuilder = querybuilder().append(
+            orm.Node,
+            project=['id', 'attributes.source.license'],
+            filters={'id': {'in': node_batch_ids}},
+        )
 
-    for node_id, name in qbuilder.iterall(batch_size=batch_size):
-        if name is None:
-            continue
-        if not check_allowed(name):
-            raise LicensingException(
-                f"Node {node_id} is licensed under '{name}' license, which is not in the list of allowed licenses"
-            )
-        if check_forbidden(name):
-            raise LicensingException(
-                f"Node {node_id} is licensed under '{name}' license, which is in the list of forbidden licenses"
-            )
+        for node_id, name in qbuilder.iterall(batch_size=batch_size):
+            if name is None:
+                continue
+            if not check_allowed(name):
+                raise LicensingException(
+                    f"Node {node_id} is licensed under '{name}' license, which is not in the list of allowed licenses"
+                )
+            if check_forbidden(name):
+                raise LicensingException(
+                    f"Node {node_id} is licensed under '{name}' license, which is in the list of forbidden licenses"
+                )
 
 
 def get_init_summary(

--- a/src/aiida/tools/archive/imports.py
+++ b/src/aiida/tools/archive/imports.py
@@ -8,9 +8,8 @@
 ###########################################################################
 """Import an archive."""
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Literal, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Literal, Optional, Set, Tuple, Union
 
 from tabulate import tabulate
 
@@ -21,6 +20,7 @@ from aiida.common.lang import type_check
 from aiida.common.links import LinkType
 from aiida.common.log import AIIDA_LOGGER
 from aiida.common.progress_reporter import get_progress_reporter
+from aiida.common.utils import DEFAULT_BATCH_SIZE, DEFAULT_FILTER_SIZE, batch_iter
 from aiida.manage import get_manager
 from aiida.orm.entities import EntityTypes
 from aiida.orm.implementation import StorageBackend
@@ -28,7 +28,7 @@ from aiida.orm.querybuilder import QueryBuilder
 from aiida.repository import Repository
 
 from .abstract import ArchiveFormatAbstract
-from .common import batch_iter, entity_type_to_orm
+from .common import entity_type_to_orm
 from .exceptions import ImportTestRun, ImportUniquenessError, ImportValidationError
 from .implementations.sqlite_zip import ArchiveFormatSqlZip
 
@@ -48,22 +48,10 @@ DUPLICATE_LABEL_MAX = 100
 DUPLICATE_LABEL_TEMPLATE = '{0} (Imported #{1})'
 
 
-@dataclass
-class QueryParams:
-    """Parameters for executing backend queries."""
-
-    batch_size: int
-    """Batch size for streaming database rows."""
-    filter_size: int
-    """Maximum number of parameters allowed in a single query filter."""
-
-
 def import_archive(
     path: Union[str, Path],
     *,
     archive_format: Optional[ArchiveFormatAbstract] = None,
-    filter_size: int = 999,
-    batch_size: int = 1000,
     import_new_extras: bool = True,
     merge_extras: MergeExtrasType = ('k', 'n', 'l'),
     merge_comments: MergeCommentsType = 'leave',
@@ -72,13 +60,13 @@ def import_archive(
     group: Optional[orm.Group] = None,
     test_run: bool = False,
     backend: Optional[StorageBackend] = None,
+    filter_size: int = DEFAULT_FILTER_SIZE,
+    batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> Optional[int]:
     """Import an archive into the AiiDA backend.
 
     :param path: the path to the archive
     :param archive_format: The class for interacting with the archive
-    :param filter_size: Maximum size of parameters allowed in a single query filter
-    :param batch_size: Batch size for streaming database rows
     :param import_new_extras: Keep extras on new nodes (except private aiida keys), else strip
     :param merge_extras: Rules for merging extras into existing nodes.
         The first letter acts on extras that are present in the original node and not present in the imported node.
@@ -99,6 +87,9 @@ def import_archive(
         If None, one will be auto-generated.
     :param test_run: if True, do not write to file
     :param backend: the backend to import to. If not specified, the default backend is used.
+    :param filter_size: query filters are batched by this number to avoid database parameter limits. Try reducing
+        this value in case you run into related errors.
+    :param batch_size: Batch size for streaming database rows
 
     :returns: Primary Key of the import Group
 
@@ -123,7 +114,6 @@ def import_archive(
     type_check(test_run, bool)
     backend = backend or get_manager().get_profile_storage()
     type_check(backend, StorageBackend)
-    query_params = QueryParams(batch_size=batch_size, filter_size=filter_size)
 
     if group and not group.is_stored:
         group.store()
@@ -165,35 +155,49 @@ def import_archive(
         # To ensure we do not corrupt the backend database on a faulty import,
         # Every addition/update is made in a single transaction, which is commited on exit
         with backend.transaction():
-            user_ids_archive_backend = _import_users(backend_from, backend, query_params)
-            computer_ids_archive_backend = _import_computers(backend_from, backend, query_params)
+            user_ids_archive_backend = _import_users(backend_from, backend, batch_size, filter_size)
+            computer_ids_archive_backend = _import_computers(backend_from, backend, batch_size, filter_size)
             if include_authinfos:
                 _import_authinfos(
-                    backend_from, backend, query_params, user_ids_archive_backend, computer_ids_archive_backend
+                    backend_from,
+                    backend,
+                    batch_size,
+                    user_ids_archive_backend,
+                    computer_ids_archive_backend,
                 )
             node_ids_archive_backend = _import_nodes(
                 backend_from,
                 backend,
-                query_params,
+                batch_size,
+                filter_size,
                 user_ids_archive_backend,
                 computer_ids_archive_backend,
                 import_new_extras,
                 merge_extras,
             )
-            _import_logs(backend_from, backend, query_params, node_ids_archive_backend)
+            _import_logs(backend_from, backend, batch_size, filter_size, node_ids_archive_backend)
             _import_comments(
-                backend_from, backend, query_params, user_ids_archive_backend, node_ids_archive_backend, merge_comments
+                backend_from,
+                backend,
+                batch_size,
+                filter_size,
+                user_ids_archive_backend,
+                node_ids_archive_backend,
+                merge_comments,
             )
-            _import_links(backend_from, backend, query_params, node_ids_archive_backend)
+            _import_links(backend_from, backend, batch_size, node_ids_archive_backend)
             group_labels = _import_groups(
-                backend_from, backend, query_params, user_ids_archive_backend, node_ids_archive_backend
+                backend_from, backend, batch_size, filter_size, user_ids_archive_backend, node_ids_archive_backend
             )
             import_group_id = None
             if create_group:
-                import_group_id = _make_import_group(
-                    group, group_labels, node_ids_archive_backend, backend, query_params
-                )
-            new_repo_keys = _get_new_object_keys(archive_format.key_format, backend_from, backend, query_params)
+                import_group_id = _make_import_group(group, group_labels, node_ids_archive_backend, backend, batch_size)
+            new_repo_keys = _get_new_object_keys(
+                archive_format.key_format,
+                backend_from,
+                backend,
+                batch_size,
+            )
 
             if test_run:
                 # exit before we write anything to the database or repository
@@ -215,7 +219,8 @@ def _add_new_entities(
     backend_unique_id: dict,
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
+    filter_size: int,
     transform: Callable[[dict], dict],
 ) -> None:
     """Add new entities to the output backend and update the mapping of unique field -> id."""
@@ -224,14 +229,14 @@ def _add_new_entities(
     # collect the unique entities from the input backend to be added to the output backend
     ufields = []
     query = QueryBuilder(backend=backend_from).append(entity_type_to_orm[etype], project=unique_field)
-    for (ufield,) in query.distinct().iterall(batch_size=query_params.batch_size):
+    for (ufield,) in query.distinct().iterall(batch_size=batch_size):
         if ufield not in backend_unique_id:
             ufields.append(ufield)
 
     with get_progress_reporter()(desc=f'Adding new {etype.value}(s)', total=total) as progress:
         # batch the filtering of rows by filter size, to limit the number of query variables used in any one query,
         # since certain backends have a limit on the number of variables in a query (such as SQLITE_MAX_VARIABLE_NUMBER)
-        for nrows, ufields_batch in batch_iter(ufields, query_params.filter_size):
+        for nrows, ufields_batch in batch_iter(ufields, filter_size):
             rows = [
                 transform(row)
                 for row in QueryBuilder(backend=backend_from)
@@ -241,7 +246,7 @@ def _add_new_entities(
                     project=['**'],
                     tag='entity',
                 )
-                .dict(batch_size=query_params.batch_size)
+                .dict(batch_size=batch_size)
             ]
             new_ids = backend_to.bulk_insert(etype, rows)
             backend_unique_id.update({row[unique_field]: pk for pk, row in zip(new_ids, rows)})
@@ -249,7 +254,7 @@ def _add_new_entities(
 
 
 def _import_users(
-    backend_from: StorageBackend, backend_to: StorageBackend, query_params: QueryParams
+    backend_from: StorageBackend, backend_to: StorageBackend, batch_size: int, filter_size: int
 ) -> Dict[int, int]:
     """Import users from one backend to another.
 
@@ -257,7 +262,7 @@ def _import_users(
     """
     # get the records from the input backend
     qbuilder = QueryBuilder(backend=backend_from)
-    input_id_email = dict(qbuilder.append(orm.User, project=['id', 'email']).all(batch_size=query_params.batch_size))
+    input_id_email = dict(qbuilder.append(orm.User, project=['id', 'email']).all(batch_size=batch_size))
 
     # get matching emails from the backend
     output_email_id: Dict[str, int] = {}
@@ -268,9 +273,9 @@ def _import_users(
                 dict(
                     orm.QueryBuilder(backend=backend_to)
                     .append(orm.User, filters={'email': {'in': chunk}}, project=['email', 'id'])
-                    .all(batch_size=query_params.batch_size)
+                    .all(batch_size=batch_size)
                 )
-                for _, chunk in batch_iter(set(input_id_email.values()), query_params.filter_size)
+                for _, chunk in batch_iter(set(input_id_email.values()), filter_size)
             ]
             for key, value in query_results.items()
         }
@@ -286,7 +291,15 @@ def _import_users(
             return {k: v for k, v in row['entity'].items() if k != 'id'}
 
         _add_new_entities(
-            EntityTypes.USER, new_users, 'email', output_email_id, backend_from, backend_to, query_params, transform
+            EntityTypes.USER,
+            new_users,
+            'email',
+            output_email_id,
+            backend_from,
+            backend_to,
+            batch_size,
+            filter_size,
+            transform,
         )
 
     # generate mapping of input backend id to output backend id
@@ -294,7 +307,7 @@ def _import_users(
 
 
 def _import_computers(
-    backend_from: StorageBackend, backend_to: StorageBackend, query_params: QueryParams
+    backend_from: StorageBackend, backend_to: StorageBackend, batch_size: int, filter_size: int
 ) -> Dict[int, int]:
     """Import computers from one backend to another.
 
@@ -302,7 +315,7 @@ def _import_computers(
     """
     # get the records from the input backend
     qbuilder = QueryBuilder(backend=backend_from)
-    input_id_uuid = dict(qbuilder.append(orm.Computer, project=['id', 'uuid']).all(batch_size=query_params.batch_size))
+    input_id_uuid = dict(qbuilder.append(orm.Computer, project=['id', 'uuid']).all(batch_size=batch_size))
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
@@ -313,9 +326,9 @@ def _import_computers(
                 dict(
                     orm.QueryBuilder(backend=backend_to)
                     .append(orm.Computer, filters={'uuid': {'in': chunk}}, project=['uuid', 'id'])
-                    .all(batch_size=query_params.batch_size)
+                    .all(batch_size=batch_size)
                 )
-                for _, chunk in batch_iter(set(input_id_uuid.values()), query_params.filter_size)
+                for _, chunk in batch_iter(set(input_id_uuid.values()), filter_size)
             ]
             for key, value in query_results.items()
         }
@@ -333,7 +346,7 @@ def _import_computers(
             label
             for (label,) in orm.QueryBuilder(backend=backend_to)
             .append(orm.Computer, project='label')
-            .iterall(batch_size=query_params.batch_size)
+            .iterall(batch_size=batch_size)
         }
         relabelled = 0
 
@@ -363,7 +376,8 @@ def _import_computers(
             backend_uuid_id,
             backend_from,
             backend_to,
-            query_params,
+            batch_size,
+            filter_size,
             transform,
         )
 
@@ -377,7 +391,7 @@ def _import_computers(
 def _import_authinfos(
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
     user_ids_archive_backend: Dict[int, int],
     computer_ids_archive_backend: Dict[int, int],
 ) -> None:
@@ -390,7 +404,7 @@ def _import_authinfos(
     input_id_user_comp = qbuilder.append(
         orm.AuthInfo,
         project=['id', 'aiidauser_id', 'dbcomputer_id'],
-    ).all(batch_size=query_params.batch_size)
+    ).all(batch_size=batch_size)
 
     # translate user_id / computer_id, from -> to
     try:
@@ -415,7 +429,7 @@ def _import_authinfos(
         )
         backend_id_user_comp = [
             (user_id, comp_id)
-            for _, user_id, comp_id in qbuilder.all(batch_size=query_params.batch_size)
+            for _, user_id, comp_id in qbuilder.all(batch_size=batch_size)
             if (user_id, comp_id) in to_user_id_comp_id
         ]
 
@@ -449,7 +463,7 @@ def _import_authinfos(
     with get_progress_reporter()(
         desc=f'Adding new {EntityTypes.AUTHINFO.value}(s)', total=qbuilder.count()
     ) as progress:
-        for nrows, rows in batch_iter(iterator, query_params.batch_size, transform):
+        for nrows, rows in batch_iter(iterator, batch_size, transform):
             backend_to.bulk_insert(EntityTypes.AUTHINFO, rows)
             progress.update(nrows)
 
@@ -457,7 +471,8 @@ def _import_authinfos(
 def _import_nodes(
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
+    filter_size: int,
     user_ids_archive_backend: Dict[int, int],
     computer_ids_archive_backend: Dict[int, int],
     import_new_extras: bool,
@@ -470,7 +485,7 @@ def _import_nodes(
     IMPORT_LOGGER.report('Collecting Node(s) ...')
     # get the records from the input backend
     qbuilder = QueryBuilder(backend=backend_from)
-    input_id_uuid = dict(qbuilder.append(orm.Node, project=['id', 'uuid']).all(batch_size=query_params.batch_size))
+    input_id_uuid = dict(qbuilder.append(orm.Node, project=['id', 'uuid']).all(batch_size=batch_size))
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
@@ -482,9 +497,9 @@ def _import_nodes(
                 dict(
                     orm.QueryBuilder(backend=backend_to)
                     .append(orm.Node, filters={'uuid': {'in': chunk}}, project=['uuid', 'id'])
-                    .all(batch_size=query_params.batch_size)
+                    .all(batch_size=batch_size)
                 )
-                for _, chunk in batch_iter(set(input_id_uuid.values()), query_params.filter_size)
+                for _, chunk in batch_iter(set(input_id_uuid.values()), filter_size)
             ]
             for key, value in query_results.items()
         }
@@ -492,13 +507,21 @@ def _import_nodes(
     new_nodes = len(input_id_uuid) - len(backend_uuid_id)
 
     if backend_uuid_id:
-        _merge_node_extras(backend_from, backend_to, query_params, backend_uuid_id, merge_extras)
+        _merge_node_extras(backend_from, backend_to, batch_size, backend_uuid_id, merge_extras)
 
     if new_nodes:
         # add new nodes and update backend_uuid_id with their uuid -> id mapping
         transform = NodeTransform(user_ids_archive_backend, computer_ids_archive_backend, import_new_extras)
         _add_new_entities(
-            EntityTypes.NODE, new_nodes, 'uuid', backend_uuid_id, backend_from, backend_to, query_params, transform
+            EntityTypes.NODE,
+            new_nodes,
+            'uuid',
+            backend_uuid_id,
+            backend_from,
+            backend_to,
+            batch_size,
+            filter_size,
+            transform,
         )
 
     # generate mapping of input backend id to output backend id
@@ -548,7 +571,8 @@ class NodeTransform:
 def _import_logs(
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
+    filter_size: int,
     node_ids_archive_backend: Dict[int, int],
 ) -> Dict[int, int]:
     """Import logs from one backend to another.
@@ -557,7 +581,7 @@ def _import_logs(
     """
     # get the records from the input backend
     qbuilder = QueryBuilder(backend=backend_from)
-    input_id_uuid = dict(qbuilder.append(orm.Log, project=['id', 'uuid']).all(batch_size=query_params.batch_size))
+    input_id_uuid = dict(qbuilder.append(orm.Log, project=['id', 'uuid']).all(batch_size=batch_size))
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
@@ -569,9 +593,9 @@ def _import_logs(
                 dict(
                     orm.QueryBuilder(backend=backend_to)
                     .append(orm.Log, filters={'uuid': {'in': chunk}}, project=['uuid', 'id'])
-                    .all(batch_size=query_params.batch_size)
+                    .all(batch_size=batch_size)
                 )
-                for _, chunk in batch_iter(set(input_id_uuid.values()), query_params.filter_size)
+                for _, chunk in batch_iter(set(input_id_uuid.values()), filter_size)
             ]
             for key, value in query_results.items()
         }
@@ -593,7 +617,15 @@ def _import_logs(
             return data
 
         _add_new_entities(
-            EntityTypes.LOG, new_logs, 'uuid', backend_uuid_id, backend_from, backend_to, query_params, transform
+            EntityTypes.LOG,
+            new_logs,
+            'uuid',
+            backend_uuid_id,
+            backend_from,
+            backend_to,
+            batch_size,
+            filter_size,
+            transform,
         )
 
     # generate mapping of input backend id to output backend id
@@ -603,7 +635,7 @@ def _import_logs(
 def _merge_node_extras(
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
     backend_uuid_id: Dict[str, int],
     mode: MergeExtrasType,
 ) -> None:
@@ -635,9 +667,7 @@ def _merge_node_extras(
             return {'id': backend_uuid_id[row[0]], 'extras': row[1]}
 
         with get_progress_reporter()(desc='Replacing extras', total=input_extras.count()) as progress:
-            for nrows, rows in batch_iter(
-                input_extras.iterall(batch_size=query_params.batch_size), query_params.batch_size, transform
-            ):
+            for nrows, rows in batch_iter(input_extras.iterall(batch_size=batch_size), batch_size, transform):
                 backend_to.bulk_update(EntityTypes.NODE, rows)
                 progress.update(nrows)
         return
@@ -658,7 +688,7 @@ def _merge_node_extras(
             f'Number of Nodes in archive ({input_extras.count()}) and backend ({backend_extras.count()}) do not match'
         )
 
-    def _transform(data: Tuple[Tuple[str, dict], Tuple[str, dict]]) -> dict:
+    def _transform(data: tuple[Any, Any]) -> dict:
         """Transform the new and existing extras into a dict that can be passed to bulk_update."""
         new_uuid, new_extras = data[0]
         old_uuid, old_extras = data[1]
@@ -717,10 +747,10 @@ def _merge_node_extras(
     with get_progress_reporter()(desc='Merging extras', total=input_extras.count()) as progress:
         for nrows, rows in batch_iter(
             zip(
-                input_extras.iterall(batch_size=query_params.batch_size),
-                backend_extras.iterall(batch_size=query_params.batch_size),
+                input_extras.iterall(batch_size=batch_size),
+                backend_extras.iterall(batch_size=batch_size),
             ),
-            query_params.batch_size,
+            batch_size,
             _transform,
         ):
             backend_to.bulk_update(EntityTypes.NODE, rows)
@@ -757,7 +787,8 @@ class CommentTransform:
 def _import_comments(
     backend_from: StorageBackend,
     backend: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
+    filter_size: int,
     user_ids_archive_backend: Dict[int, int],
     node_ids_archive_backend: Dict[int, int],
     merge_comments: MergeCommentsType,
@@ -768,7 +799,7 @@ def _import_comments(
     """
     # get the records from the input backend
     qbuilder = QueryBuilder(backend=backend_from)
-    input_id_uuid = dict(qbuilder.append(orm.Comment, project=['id', 'uuid']).all(batch_size=query_params.batch_size))
+    input_id_uuid = dict(qbuilder.append(orm.Comment, project=['id', 'uuid']).all(batch_size=batch_size))
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
@@ -776,7 +807,7 @@ def _import_comments(
         backend_uuid_id = dict(
             orm.QueryBuilder(backend=backend)
             .append(orm.Comment, filters={'uuid': {'in': list(input_id_uuid.values())}}, project=['uuid', 'id'])
-            .all(batch_size=query_params.batch_size)
+            .all(batch_size=batch_size)
         )
 
     new_comments = len(input_id_uuid) - len(backend_uuid_id)
@@ -797,9 +828,7 @@ def _import_comments(
                 return data
 
             with get_progress_reporter()(desc='Overwriting comments', total=archive_comments.count()) as progress:
-                for nrows, rows in batch_iter(
-                    archive_comments.iterall(batch_size=query_params.batch_size), query_params.batch_size, _transform
-                ):
+                for nrows, rows in batch_iter(archive_comments.iterall(batch_size=batch_size), batch_size, _transform):
                     backend.bulk_update(EntityTypes.COMMENT, rows)
                     progress.update(nrows)
 
@@ -815,9 +844,7 @@ def _import_comments(
                     cmt.set_content(new_comment)
 
             with get_progress_reporter()(desc='Updating comments', total=archive_comments.count()) as progress:
-                for nrows, rows in batch_iter(
-                    archive_comments.iterall(batch_size=query_params.batch_size), query_params.batch_size, _transform
-                ):
+                for nrows, rows in batch_iter(archive_comments.iterall(batch_size=batch_size), batch_size, _transform):
                     progress.update(nrows)
 
         else:
@@ -831,7 +858,8 @@ def _import_comments(
             backend_uuid_id,
             backend_from,
             backend,
-            query_params,
+            batch_size,
+            filter_size,
             CommentTransform(user_ids_archive_backend, node_ids_archive_backend),
         )
 
@@ -842,7 +870,7 @@ def _import_comments(
 def _import_links(
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
     node_ids_archive_backend: Dict[int, int],
 ) -> None:
     """Import links from one backend to another."""
@@ -900,7 +928,7 @@ def _import_links(
             tuple(link)
             for link in orm.QueryBuilder(backend=backend_to)
             .append(entity_type='link', filters={'type': link_type.value}, project=['input_id', 'output_id', 'label'])
-            .iterall(batch_size=query_params.batch_size)
+            .iterall(batch_size=batch_size)
         }
         # create additional validators
         # note, we only populate them when required, to reduce memory usage
@@ -916,9 +944,7 @@ def _import_links(
         new_count = existing_count = 0
         insert_rows = []
         with get_progress_reporter()(desc=f'Processing {link_type.value!r} Link(s)', total=total) as progress:
-            for in_id, in_type, out_id, out_type, link_id, link_label in archive_query.iterall(
-                batch_size=query_params.batch_size
-            ):
+            for in_id, in_type, out_id, out_type, link_id, link_label in archive_query.iterall(batch_size=batch_size):
                 progress.update()
 
                 # convert ids: archive -> profile
@@ -972,7 +998,7 @@ def _import_links(
                 existing_out_id_label.add((out_id, link_label))
 
                 # flush new rows, once batch size is reached
-                if (new_count % query_params.batch_size) == 0:
+                if (new_count % batch_size) == 0:
                     backend_to.bulk_insert(EntityTypes.LINK, insert_rows)
                     insert_rows = []
 
@@ -1022,7 +1048,8 @@ class GroupTransform:
 def _import_groups(
     backend_from: StorageBackend,
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
+    filter_size: int,
     user_ids_archive_backend: Dict[int, int],
     node_ids_archive_backend: Dict[int, int],
 ) -> Set[str]:
@@ -1032,7 +1059,7 @@ def _import_groups(
     """
     # get the records from the input backend
     qbuilder = QueryBuilder(backend=backend_from)
-    input_id_uuid = dict(qbuilder.append(orm.Group, project=['id', 'uuid']).all(batch_size=query_params.batch_size))
+    input_id_uuid = dict(qbuilder.append(orm.Group, project=['id', 'uuid']).all(batch_size=batch_size))
 
     # get matching uuids from the backend
     backend_uuid_id: Dict[str, int] = {}
@@ -1040,7 +1067,7 @@ def _import_groups(
         backend_uuid_id = dict(
             orm.QueryBuilder(backend=backend_to)
             .append(orm.Group, filters={'uuid': {'in': list(input_id_uuid.values())}}, project=['uuid', 'id'])
-            .all(batch_size=query_params.batch_size)
+            .all(batch_size=batch_size)
         )
 
     # get all labels
@@ -1048,7 +1075,7 @@ def _import_groups(
         label
         for (label,) in orm.QueryBuilder(backend=backend_to)
         .append(orm.Group, project='label')
-        .iterall(batch_size=query_params.batch_size)
+        .iterall(batch_size=batch_size)
     }
 
     new_groups = len(input_id_uuid) - len(backend_uuid_id)
@@ -1063,7 +1090,15 @@ def _import_groups(
         transform = GroupTransform(user_ids_archive_backend, labels)
 
         _add_new_entities(
-            EntityTypes.GROUP, new_groups, 'uuid', backend_uuid_id, backend_from, backend_to, query_params, transform
+            EntityTypes.GROUP,
+            new_groups,
+            'uuid',
+            backend_uuid_id,
+            backend_from,
+            backend_to,
+            batch_size,
+            filter_size,
+            transform,
         )
 
         if transform.relabelled:
@@ -1091,7 +1126,7 @@ def _import_groups(
 
             with get_progress_reporter()(desc=f'Adding new {EntityTypes.GROUP_NODE.value}(s)', total=total) as progress:
                 for nrows, rows in batch_iter(
-                    iterator.iterall(batch_size=query_params.batch_size), query_params.batch_size, group_node_transform
+                    iterator.iterall(batch_size=batch_size), batch_size, group_node_transform
                 ):
                     backend_to.bulk_insert(EntityTypes.GROUP_NODE, rows)
                     progress.update(nrows)
@@ -1104,7 +1139,7 @@ def _make_import_group(
     labels: Set[str],
     node_ids_archive_backend: Dict[int, int],
     backend_to: StorageBackend,
-    query_params: QueryParams,
+    batch_size: int,
 ) -> Optional[int]:
     """Make an import group containing all imported nodes.
 
@@ -1150,7 +1185,7 @@ def _make_import_group(
             for (pk,) in orm.QueryBuilder(backend=backend_to)
             .append(orm.Group, filters={'id': group_id}, tag='group')
             .append(orm.Node, with_group='group', project='id')
-            .iterall(batch_size=query_params.batch_size)
+            .iterall(batch_size=batch_size)
         }
 
     # Add all the nodes to the Group
@@ -1162,7 +1197,7 @@ def _make_import_group(
             for node_id in node_ids_archive_backend.values()
             if node_id not in group_node_ids
         )
-        for nrows, rows in batch_iter(iterator, query_params.batch_size):
+        for nrows, rows in batch_iter(iterator, batch_size):
             backend_to.bulk_insert(EntityTypes.GROUP_NODE, rows)
             progress.update(nrows)
 
@@ -1170,13 +1205,16 @@ def _make_import_group(
 
 
 def _get_new_object_keys(
-    key_format: str, backend_from: StorageBackend, backend_to: StorageBackend, query_params: QueryParams
+    key_format: str,
+    backend_from: StorageBackend,
+    backend_to: StorageBackend,
+    batch_size: int,
 ) -> Set[str]:
     """Return the object keys that need to be added to the backend."""
     archive_hashkeys: Set[str] = set()
     query = QueryBuilder(backend=backend_from).append(orm.Node, project='repository_metadata')
     with get_progress_reporter()(desc='Collecting archive Node file keys', total=query.count()) as progress:
-        for (repository_metadata,) in query.iterall(batch_size=query_params.batch_size):
+        for (repository_metadata,) in query.iterall(batch_size=batch_size):
             archive_hashkeys.update(key for key in Repository.flatten(repository_metadata).values() if key is not None)
             progress.update()
 

--- a/tests/benchmark/test_archive.py
+++ b/tests/benchmark/test_archive.py
@@ -18,8 +18,10 @@ import pytest
 
 from aiida.common.links import LinkType
 from aiida.engine import ProcessState
-from aiida.orm import CalcFunctionNode, Dict, load_node
+from aiida.orm import CalcFunctionNode, Dict, Node, QueryBuilder, load_node
 from aiida.tools.archive import create_archive, import_archive
+
+GROUP_NAME = 'import-export'
 
 
 def recursive_provenance(in_node, depth, breadth, num_objects=0):
@@ -68,7 +70,7 @@ TREE = {'no-objects': (4, 3, 0), 'with-objects': (4, 3, 2)}
 
 
 @pytest.mark.parametrize('depth,breadth,num_objects', TREE.values(), ids=TREE.keys())
-@pytest.mark.benchmark(group='import-export')
+@pytest.mark.benchmark(group=GROUP_NAME)
 def test_export(benchmark, tmp_path, depth, breadth, num_objects):
     """Benchmark exporting a provenance graph."""
     root_node = Dict()
@@ -88,7 +90,7 @@ def test_export(benchmark, tmp_path, depth, breadth, num_objects):
 
 
 @pytest.mark.parametrize('depth,breadth,num_objects', TREE.values(), ids=TREE.keys())
-@pytest.mark.benchmark(group='import-export')
+@pytest.mark.benchmark(group=GROUP_NAME)
 def test_import(aiida_profile, benchmark, tmp_path, depth, breadth, num_objects):
     """Benchmark importing a provenance graph."""
     aiida_profile.reset_storage()
@@ -107,3 +109,58 @@ def test_import(aiida_profile, benchmark, tmp_path, depth, breadth, num_objects)
 
     benchmark.pedantic(_run, setup=_setup, iterations=1, rounds=12, warmup_rounds=1)
     load_node(root_uuid)
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+@pytest.mark.benchmark(group='large-archive')
+def test_large_archive_export_benchmark(tmp_path, benchmark):
+    """Benchmark export performance with different filter_size values using 10k nodes."""
+    from tests.utils.nodes import create_int_nodes
+
+    num_nodes = 10_000
+
+    # Setup: create nodes (not benchmarked)
+    _ = create_int_nodes(num_nodes)
+    export_file = tmp_path / 'export_benchmark.aiida'
+
+    def export_operation():
+        create_archive(entities=None, filename=export_file, overwrite=True)
+
+    benchmark.pedantic(export_operation, rounds=3, iterations=1)
+
+    # Verify export succeeded
+    assert export_file.exists()
+
+
+@pytest.mark.usefixtures('aiida_profile_clean')
+@pytest.mark.benchmark(group='large-archive')
+def test_large_archive_import_benchmark(tmp_path, benchmark, aiida_profile_clean):
+    """Benchmark import performance with different filter_size values using 10k nodes."""
+    from tests.utils.nodes import create_int_nodes
+
+    num_nodes = 10_000
+
+    def setup():
+        """Create archive for import benchmarking (setup phase, not timed)."""
+        # Create nodes and export to archive
+        export_file = tmp_path / 'import_benchmark.aiida'
+        # archive is being created in the multiple runs of the benchmark
+        # archive creation is not timed, so we can re-use if it already exists
+        if export_file.exists():
+            return (export_file,), {}
+        else:
+            _ = create_int_nodes(num_nodes)
+            _ = create_archive(entities=None, filename=export_file, overwrite=False)
+        return (export_file,), {}
+
+    def import_operation(export_file):
+        """The actual import operation to benchmark."""
+        aiida_profile_clean.reset_storage()
+        import_archive(export_file)
+
+    # Use benchmark.pedantic with setup function
+    benchmark.pedantic(import_operation, setup=setup, rounds=3, iterations=1)
+
+    # Verify correctness after benchmark
+    all_nodes = QueryBuilder().append(Node).all(flat=True)
+    assert len(all_nodes) == num_nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ import pytest
 from aiida import get_profile, orm
 from aiida.common.folders import Folder
 from aiida.common.links import LinkType
+from aiida.manage import get_manager
 from aiida.manage.configuration import Profile, get_config, load_profile
 
 try:
@@ -351,7 +352,7 @@ def empty_config(tmp_path) -> Config:
     :return: a new empty config instance.
     """
     from aiida.common.utils import Capturing
-    from aiida.manage import configuration, get_manager
+    from aiida.manage import configuration
     from aiida.manage.configuration.settings import AiiDAConfigDir
 
     manager = get_manager()
@@ -491,7 +492,6 @@ def config_with_profile(config_with_profile_factory):
 @pytest.fixture
 def manager():
     """Get the ``Manager`` instance of the currently loaded profile."""
-    from aiida.manage import get_manager
 
     return get_manager()
 

--- a/tests/storage/psql_dos/test_groups.py
+++ b/tests/storage/psql_dos/test_groups.py
@@ -8,28 +8,26 @@
 ###########################################################################
 """Regression test for bulk group operations with PSQL backend."""
 
-from pathlib import Path
-
 import pytest
 
 from aiida import orm
-from aiida.tools.archive import import_archive
 
 
 @pytest.mark.requires_psql
-@pytest.mark.nightly
+@pytest.mark.nightly  # takes ~1 min
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_group_bulk_operations():
-    """
-    Regression test for the PostgreSQL parameter limit OperationalError on add_nodes using a pre-created archive.
-    """
-    num_nodes = 50_000
-    archive_path = Path(__file__).parents[2] / 'data' / f'{int(num_nodes/1000)}k-int-nodes-2.7.1.post0.aiida'
-    import_archive(archive_path)
+    """Regression test for the PostgreSQL parameter limit OperationalError on add_nodes."""
+    from tests.utils.nodes import create_int_nodes
 
-    qb = orm.QueryBuilder()
-    qb.append(orm.Int)
-    nodes = qb.all(flat=True)
+    num_nodes = 34_000  # Minimum number to reach exception without the fix
+
+    # Create nodes using the efficient bulk_insert method
+    node_pks = create_int_nodes(num_nodes)
+    assert len(node_pks) == num_nodes
+
+    # Get the actual node objects for group operations
+    nodes = orm.QueryBuilder().append(orm.Int).all(flat=True)
     assert len(nodes) == num_nodes
 
     # Test the group operations that were failing

--- a/tests/tools/archive/test_complex.py
+++ b/tests/tools/archive/test_complex.py
@@ -196,3 +196,57 @@ def get_hash_from_db_content(grouplabel):
         ]
     )
     return hash_
+
+
+def test_complex_export_filter_size(tmp_path, aiida_profile_clean):
+    """Test export with various entity types when filter_size limits are exceeded."""
+    # Create multiple entity types to test different code paths
+    nb_entities = 10
+
+    # Create users (will need nodes attached to be exported)
+    users = []
+    for i in range(nb_entities):
+        user = orm.User(email=f'user{i}@example.com').store()
+        users.append(user)
+
+    # Create nodes with different users
+    nodes = []
+    for i, user in enumerate(users):
+        node = orm.Int(i, user=user)
+        node.label = f'node_{i}'
+        node.store()
+        nodes.append(node)
+
+    # Create some links between nodes
+    calc_nodes = []
+    for i in range(min(3, nb_entities)):
+        calc = orm.CalculationNode()
+        calc.base.links.add_incoming(nodes[i], LinkType.INPUT_CALC, f'input_{i}')
+        calc.store()
+        calc.seal()
+        calc_nodes.append(calc)
+        nodes.append(calc)
+
+    # Export with small filter_size to force batching in multiple functions
+    export_file = tmp_path / 'large_export.aiida'
+    create_archive(nodes, filename=export_file, filter_size=3)
+
+    # Verify by importing
+    aiida_profile_clean.reset_storage()
+    import_archive(export_file)
+
+    # Check all entities were properly exported/imported
+    assert orm.QueryBuilder().append(orm.Node).count() == len(nodes)
+    assert orm.QueryBuilder().append(orm.User).count() == nb_entities + 1  # +1 for default user
+
+    # Assert for calculation nodes specifically
+    calc_node_count = orm.QueryBuilder().append(orm.CalculationNode).count()
+    assert calc_node_count == len(calc_nodes)
+
+    # Assert for data nodes specifically
+    data_node_count = orm.QueryBuilder().append(orm.Int).count()
+    assert data_node_count == nb_entities
+
+    # Verify links were preserved
+    link_count = orm.QueryBuilder().append(entity_type='link').count()
+    assert link_count >= 3  # At least the links we created

--- a/tests/tools/archive/test_regression.py
+++ b/tests/tools/archive/test_regression.py
@@ -1,0 +1,38 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Regression tests for large archive import/exports, e.g., to capture ``OperationalError``s."""
+
+import pytest
+
+from aiida import orm
+from aiida.tools.archive import create_archive, import_archive
+
+
+@pytest.mark.timeout(1000)  # Should finish in ~300s
+@pytest.mark.nightly
+def test_large_archive_export_operr_regression(pytestconfig, tmp_path, aiida_profile_clean):
+    """Regression test: ensure OperationalError occurs (not) with too large (sufficiently small) filter_size."""
+
+    from tests.utils.nodes import create_int_nodes
+
+    num_nodes = 66_000  # Minimum value that OpErr is raised
+
+    _ = create_int_nodes(num_nodes)
+
+    # NOTE: Need to obtain a selection of `orm.Node`s, otherwise, with `entities=None`,
+    # where the profile is exported in full the `_collect_all_entities` method that
+    # doesn't apply any QB filters is called
+    orm_nodes = orm.QueryBuilder().append(orm.Node).all(flat=True)
+
+    # NOTE: Both, import and export should pass with both backends
+    export_file = tmp_path / 'should_work.aiida'
+    create_archive(entities=orm_nodes, filename=export_file)
+
+    aiida_profile_clean.reset_storage()
+    import_archive(path=export_file)

--- a/tests/tools/archive/test_simple.py
+++ b/tests/tools/archive/test_simple.py
@@ -154,3 +154,31 @@ def test_control_of_licenses(tmp_path):
 
     with pytest.raises(LicensingException):
         create_archive([struct], test_run=True, forbidden_licenses=crashing_filter)
+
+
+def test_export_filter_size(tmp_path, aiida_profile_clean):
+    """Test that export still works when the number of entities exceeds filter_size limit."""
+    # Create multiple entities that will trigger filter_size batching
+    nb_nodes = 5
+    nodes = []
+    for i in range(nb_nodes):
+        node = orm.Int(i)
+        node.label = f'node_{i}'
+        node.store()
+        nodes.append(node)
+
+    # Export with a small filter_size to force batching
+    export_file = tmp_path / 'export.aiida'
+    create_archive(nodes, filename=export_file, filter_size=2)
+
+    # Verify export was successful by importing and checking
+    aiida_profile_clean.reset_storage()
+    import_archive(export_file)
+
+    # Check all nodes were exported/imported correctly
+    builder = orm.QueryBuilder().append(orm.Node, project=['label'])
+    imported_nodes = builder.all(flat=True)
+
+    assert len(imported_nodes) == nb_nodes
+    expected_labels = [f'node_{i}' for i in range(nb_nodes)]
+    assert set(imported_nodes) == set(expected_labels)

--- a/tests/utils/nodes.py
+++ b/tests/utils/nodes.py
@@ -1,0 +1,50 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Utilities for node-related testing."""
+
+import uuid
+
+from aiida import orm
+from aiida.common import timezone
+from aiida.manage import get_manager
+
+
+def create_int_nodes(num_nodes, backend=None):
+    """Create a specified number of Int nodes efficiently using bulk_insert.
+
+    :param num_nodes: Number of nodes to create
+    :param backend: Optional backend instance. If None, uses default profile storage.
+    :returns: List of PKs of orm.Int nodes created in profile storage
+    """
+    if backend is None:
+        backend = get_manager().get_profile_storage()
+
+    assert backend.default_user is not None
+
+    current_time = timezone.now()
+
+    nodes_data = []
+    for i in range(num_nodes):
+        node_data = {
+            'uuid': str(uuid.uuid4()),
+            'node_type': 'data.core.int.Int.',
+            'process_type': None,
+            'label': f'test_node_{i}',
+            'description': 'Test node for integration testing',
+            'user_id': backend.default_user.pk,
+            'dbcomputer_id': None,
+            'ctime': current_time,
+            'mtime': current_time,
+            'attributes': {'value': i},
+            'extras': {},
+            'repository_metadata': {},
+        }
+        nodes_data.append(node_data)
+
+    return backend.bulk_insert(entity_type=orm.entities.EntityTypes.NODE, rows=nodes_data)


### PR DESCRIPTION
## Summary by Sourcery

Apply filter_size chunking across all archive import functions to chunk large queries and improve memory efficiency

Enhancements:
- Batch archive import queries using `filter_size` to avoid backend parameter limits
- Refactor authinfo, node extras, comments, and group import functions to process in chunks via batch_iter
- Batch node insertions in `_make_import_group` to reduce memory footprint for large node sets

Chores:
- Update import path for DEFAULT_BATCH_SIZE and DEFAULT_FILTER_SIZE to `aiida.common.utils`
- Remove unused QueryParams dataclass stub